### PR TITLE
Fixed saving of settings

### DIFF
--- a/src/js/store.js
+++ b/src/js/store.js
@@ -5,7 +5,7 @@ let store = {
 	peek: {},
 	job_stats: {},
 	settings: {
-		connection: "localhost",
+		address: "localhost",
 		port: 11300,
 		pause_delay: 3600
 	}


### PR DESCRIPTION
Nodestalker config expects `{address: '127.0.0.1'}` rather than `{connection: '127.0.0.1'}`.
